### PR TITLE
Maintenance version 1.2.3

### DIFF
--- a/src/lib/convert.py
+++ b/src/lib/convert.py
@@ -88,13 +88,14 @@ def check_mediatype(image_dir, excluded_mediatypes=None):
             for layer in data["layers"]:
                 if "mediaType" in layer:
                     media_types.append(layer["mediaType"])
-        excluded_types = [
+        # Use a set to collect unique excluded media types
+        excluded_types = set([
             media_type
             for media_type in media_types
             if media_type in excluded_mediatypes
-        ]
+        ])
         if excluded_types:
-            print(f"Excluded media types found: {excluded_types} in {image_dir}")
+            print(f"Excluded media types found: {list(excluded_types)} in {image_dir}")
             excluded = True
         else:
             print("No excluded media types found, continuing.")

--- a/src/lib/install.py
+++ b/src/lib/install.py
@@ -68,8 +68,10 @@ def install_package(package_name, version):
     os.makedirs(f"tmp_{package_name}", exist_ok=True)
     # Extract tarball
     Archive(f"{package_name}_v{version}.tar.gz").extractall(f"tmp_{package_name}")
-    # Move binary to "/usr/local/bin/"
-    shutil.move(f"tmp_{package_name}/{package_name}", f"/usr/local/bin/{package_name}")
+ # Instead of shutil.move, use shutil.copy and os.remove for cross-device compatibility
+    shutil.copy(f"tmp_{package_name}/{package_name}", f"/usr/local/bin/{package_name}")
+    # Delete the original file after copying
+    os.remove(f"tmp_{package_name}/{package_name}")
     # Delete temporary files and directories
     shutil.rmtree(f"tmp_{package_name}", ignore_errors=True)
     os.remove(f"{package_name}_v{version}.tar.gz")

--- a/src/lib/install.py
+++ b/src/lib/install.py
@@ -7,7 +7,7 @@ import requests
 from pyunpack import Archive
 
 # Define the scanners and their versions
-scanners = {"syft": "1.3.0", "grype": "0.77.3", "trivy": "0.51.1"}
+scanners = {"syft": "1.8.0", "grype": "0.79.1", "trivy": "0.53.0"}
 
 # Define the base URLs for the scanners
 ANCHORE_BASE_URL = (


### PR DESCRIPTION
bump versions:
- syft 1.8.0 from 1.3.0
- grype 0.79.1 from 0.77.3
- trivy 0.53.0 from 0.51.1

Excluded media types found output will now be more precise, only mediatype found in a list will be show.

Fix a bug during installation:  
> Invalid cross-device link: 'tmp_syft/syft' -> '/usr/local/bin/syft'